### PR TITLE
貸出編集機能修正

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -183,22 +183,34 @@ public class RentalManageController {
 
             });
 
+            Integer status = rentalManageDto.getStatus();
+
             String stockId = rentalManageDto.getStockId();
 
             Long rentalSumEdit = this.rentalManageService.countByStatusAndNotId(Long.parseLong(id), stockId);
 
-            if (!(rentalSumEdit == 0)) {
-                Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
-                Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
-                Long rentalNum = this.rentalManageService.countByStatusAndExpectedReturnBeforeAndNotId(expectedRentalOn,
-                        expectedReturnOn, Long.parseLong(id), stockId);
+            if (status == 0 || status == 1) {
+                if (!(rentalSumEdit == 0)) {
+                    Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
+                    Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
+                    Long rentalNum = this.rentalManageService.countByStatusAndExpectedReturnBeforeAndNotId(
+                            expectedRentalOn,
+                            expectedReturnOn, Long.parseLong(id), stockId);
 
-                if (!(rentalSumEdit == rentalNum)) {
-                    rentalErrorEdit = "この期間は貸出できません";
-                    result.addError(new FieldError("rentalManage", "expectedRentalOn", rentalErrorEdit));
-                    result.addError(new FieldError("rentalManage", "expectedReturnOn", rentalErrorEdit));
+                    if (!(rentalSumEdit == rentalNum)) {
+                        rentalErrorEdit = "この期間は貸出できません";
+                        result.addError(new FieldError("rentalManage", "expectedRentalOn", rentalErrorEdit));
+                        result.addError(new FieldError("rentalManage", "expectedReturnOn", rentalErrorEdit));
 
+                    }
                 }
+            }
+
+            // 日付チェック
+            String DateError = rentalManageDto.isDateError(rentalManage, rentalManageDto);
+            if (DateError != null) {
+                result.addError(new FieldError("rentalManageDto", "expectedRentalOn", DateError));
+                throw new RuntimeException();
             }
 
             if (result.hasErrors()) {
@@ -206,7 +218,7 @@ public class RentalManageController {
             }
 
             // 更新処理
-            this.rentalManageService.update(Long.valueOf(id), rentalManageDto);
+            this.rentalManageService.update(Long.valueOf(id), rentalManageDto, rentalManage);
 
             return "redirect:/rental/index";
         } catch (Exception e) {

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -1,6 +1,8 @@
 package jp.co.metateam.library.model;
  
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
  
 import org.springframework.format.annotation.DateTimeFormat;
@@ -66,4 +68,23 @@ public class RentalManageDto {
    
 }
 
+    //日付チェック
+    public String isDateError(RentalManage rentalManage, RentalManageDto rentalManageDto) {
+        LocalDate nowDate = LocalDate.now(ZoneId.of("Asia/Tokyo"));
+
+        //古いステータスと新しいステータス
+        Integer preStatus = rentalManage.getStatus();
+        Integer postStatus = rentalManageDto.getStatus();
+
+        //両予定日をLocalDate型に変換
+        LocalDate expectedRentalOn = rentalManageDto.getExpectedRentalOn().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+
+        //if文・貸出待ち→貸出中
+        if(preStatus == 0 && postStatus == 1) {
+            if(!expectedRentalOn.equals(nowDate)) {
+                return "現在の日付を選択してください";
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -105,7 +105,7 @@ public class RentalManageService {
 
     // 更新
     @Transactional
-    public void update(Long id, RentalManageDto rentalManageDto) throws Exception {
+    public void update(Long id, RentalManageDto rentalManageDto, RentalManage rentalManage) throws Exception {
         try {
             // 既存レコード取得
             RentalManage updateTargetRental = this.rentalManageRepository.findById(id).orElse(null);
@@ -121,6 +121,8 @@ public class RentalManageService {
             if (stock == null) {
                 throw new Exception("Stock not found.");
             }
+            //追加部分（rentalがデータに入る）
+            rentalManage = setRentalStatusDate(rentalManage, rentalManageDto.getStatus());
 
             updateTargetRental.setId(rentalManageDto.getId());
             updateTargetRental.setAccount(account);

--- a/src/main/resources/templates/rental/add.html
+++ b/src/main/resources/templates/rental/add.html
@@ -23,7 +23,7 @@
                 <form id="rental_add_form" th:object="${rentalManageDto}" th:action="@{/rental/add}" method="post">
                     <div class="mb30">
                         <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
-                        <select id="employeeId" class="form_input" name="employeeId" required>
+                        <select id="employeeId" class="form_input" name="employeeId">
                             <option value="">社員番号を選択</option>
                             <option th:each="account : ${accounts}" th:value="${account.employeeId}"
                                 th:text="${account.employeeId + ' ' + account.name}"
@@ -37,7 +37,7 @@
                                 class="text-red asterisk">＊</span></label>
                         <input type="date" id="expectedRentalOn" class="form_input" name="expectedRentalOn"
                             th:value="${#dates.format(rentalManageDto.expectedRentalOn, ('yyyy-MM-dd'))}"
-                            placeholder="貸出予定日を入力" required>
+                            placeholder="貸出予定日を入力" >
                         <div class="error_msg" th:if="${#fields.hasErrors('expectedRentalOn')}"
                             th:errors="*{expectedRentalOn}"></div>
                     </div>
@@ -46,14 +46,14 @@
                                 class="text-red asterisk">＊</span></label>
                         <input type="date" id="expectedReturnOn" class="form_input" name="expectedReturnOn"
                             th:value="${#dates.format(rentalManageDto.expectedReturnOn, ('yyyy-MM-dd'))}"
-                            placeholder="返却予定日を入力" required>
+                            placeholder="返却予定日を入力" >
                         <div class="error_msg" th:if="${#fields.hasErrors('expectedReturnOn')}"
                             th:errors="*{expectedReturnOn}"></div>
                     </div>
                     <div class="mb30">
                         <label class="input_title" for="stockMngNumber">在庫管理番号<span
                                 class="text-red asterisk">＊</span></label>
-                        <select id="stockMngNumber" class="form_input" name="stockId" required>
+                        <select id="stockMngNumber" class="form_input" name="stockId" >
                             <option value="">在庫管理番号を選択</option>
                             <option th:each="stock : ${stockList}" th:value="${stock.id}"
                                 th:text="${stock.id + ' ' + stock.bookMst.title}"
@@ -64,7 +64,7 @@
                     <div class="mb30">
                         <label class="input_title" for="rentalStatus">貸出ステータス<span
                                 class="text-red asterisk">＊</span></label>
-                        <select id="rentalStatus" class="form_input" name="status" required>
+                        <select id="rentalStatus" class="form_input" name="status">
                             <option value="">ステータスを選択</option>
                             <option th:each="status : ${rentalStatus}" th:value="${status.value}"
                                 th:text="${status.text}" th:selected="${status.value == rentalManageDto.status}">

--- a/src/main/resources/templates/rental/edit.html
+++ b/src/main/resources/templates/rental/edit.html
@@ -23,7 +23,7 @@
                 <form id="rental_add_form" th:object="${rentalManage}" th:action="@{/rental/{id}/edit(id=*{id})}" method="post">
                     <div class="mb30">
                         <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
-                        <select id="employeeId" class="form_input" name="employeeId" required>
+                        <select id="employeeId" class="form_input" name="employeeId">
                             <option value="">社員番号を選択</option>
                             <option th:each="account : ${accounts}" th:value="${account.employeeId}"
                                 th:text="${account.employeeId + ' ' + account.name}"
@@ -37,7 +37,7 @@
                                 class="text-red asterisk">＊</span></label>
                         <input type="date" id="expectedRentalOn" class="form_input" name="expectedRentalOn"
                             th:value="${#dates.format(rentalManage.expectedRentalOn, ('yyyy-MM-dd'))}"
-                            placeholder="貸出予定日を入力" required>
+                            placeholder="貸出予定日を入力">
                         <div class="error_msg" th:if="${#fields.hasErrors('expectedRentalOn')}"
                             th:errors="*{expectedRentalOn}"></div>
                     </div>
@@ -46,14 +46,14 @@
                                 class="text-red asterisk">＊</span></label>
                         <input type="date" id="expectedReturnOn" class="form_input" name="expectedReturnOn"
                             th:value="${#dates.format(rentalManage.expectedReturnOn, ('yyyy-MM-dd'))}"
-                            placeholder="返却予定日を入力" required>
+                            placeholder="返却予定日を入力">
                         <div class="error_msg" th:if="${#fields.hasErrors('expectedReturnOn')}"
                             th:errors="*{expectedReturnOn}"></div>
                     </div>
                     <div class="mb30">
                         <label class="input_title" for="stockMngNumber">在庫管理番号<span
                                 class="text-red asterisk">＊</span></label>
-                        <select id="stockMngNumber" class="form_input" name="stockId" required>
+                        <select id="stockMngNumber" class="form_input" name="stockId">
                             <option value="">在庫管理番号を選択</option>
                             <option th:each="stock : ${stockList}" th:value="${stock.id}"
                                 th:text="${stock.id + ' ' + stock.bookMst.title}"
@@ -64,7 +64,7 @@
                     <div class="mb30">
                         <label class="input_title" for="rentalStatus">貸出ステータス<span
                                 class="text-red asterisk">＊</span></label>
-                        <select id="rentalStatus" class="form_input" name="status" required>
+                        <select id="rentalStatus" class="form_input" name="status">
                             <option value="">ステータスを選択</option>
                             <option th:each="status : ${rentalStatus}" th:value="${status.value}"
                                 th:text="${status.text}" th:selected="${status.value == rentalManage.status}">


### PR DESCRIPTION
概要
・貸出ステータスを貸出中にする際、貸出日が登録されるように修正
・貸出ステータスを貸出中にする際、貸出予定日に現在日時出ないとエラーメッセージが表示されるよう修正
・エラーメッセージが同時に出力されるよう修正

テスト証跡
・貸出ステータスを貸出中に変更した際、貸出予定日が現在日時出ないとエラーメッセージが表示されるか、また、無事貸出編集ができた場合、DBに貸出日が登録されているか
・エラーメッセージが同時に複数表示されるか

備考
・特になし