### PR TITLE
在庫カレンダー機能追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -1,5 +1,6 @@
 package jp.co.metateam.library.controller;
 
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -18,6 +19,8 @@ import jp.co.metateam.library.service.RentalManageService;
 import jp.co.metateam.library.service.StockService;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
 import jp.co.metateam.library.model.RentalManageDto;
 import jp.co.metateam.library.service.BookMstService;
 import jp.co.metateam.library.model.BookMst;
@@ -75,17 +78,59 @@ public class RentalManageController {
     }
 
     @GetMapping("/rental/add")
-    public String add(Model model, @ModelAttribute RentalManageDto rentalManageDto) {
+    public String add(Model model, @ModelAttribute RentalManageDto rentalManageDto,
+            @RequestParam(value = "year", required = false) Integer year,
+            @RequestParam(value = "month", required = false) Integer month,
+            @RequestParam(value = "day", required = false) Integer day,
+            @RequestParam(value = "title", required = false) Integer title) {
         List<Account> accounts = this.accountService.findAll();
         List<Stock> stockList = this.stockService.findStockAvailableAll();
+        /// Integer id = title + 1;
+        /// RentalManage rentalManage =
+        /// this.rentalManageService.findById(Long.valueOf(id));
+        // LocalDate localDate = LocalDate.of(year, month, day);
+        // java.sql.Date choiceDate = java.sql.Date.valueOf(localDate);
 
-        model.addAttribute("accounts", accounts);
-        model.addAttribute("stockList", stockList);
-        model.addAttribute("rentalStatus", RentalStatus.values());
+        if (year != null && month != null && day != null && title != null) {
+            LocalDate localDate = LocalDate.of(year, month, day);
+            java.sql.Date choiceDate = java.sql.Date.valueOf(localDate);
+            List<Stock> availableStock = this.stockService.availableStockValues(choiceDate, title);
+            model.addAttribute("stockList", availableStock);
+
+            // RentalManage rentalManage =
+            // this.rentalManageService.findById(Long.valueOf(id));
+            // RentalManageDto rentalManageDto = new RentalManageDto();
+
+            rentalManageDto.setId(null);
+            rentalManageDto.setEmployeeId(null);
+            rentalManageDto.setExpectedRentalOn(null);
+            rentalManageDto.setExpectedReturnOn(null);
+            rentalManageDto.setStockId(null);
+            rentalManageDto.setStatus(null);
+            rentalManageDto.setExpectedRentalOn(choiceDate);
+
+            model.addAttribute("rentalManageDto", rentalManageDto);
+
+        } else {
+
+            model.addAttribute("accounts", accounts);
+            model.addAttribute("stockList", stockList);
+            model.addAttribute("rentalStatus", RentalStatus.values());
+
+        }
 
         if (!model.containsAttribute("rentalManageDto")) {
+
             model.addAttribute("rentalManageDto", new RentalManageDto());
+
+            // RentalManageDto choicedDate = new RentalManageDto();
+            /// choicedDate.setExpectedRentalOn(this.stockService.availableStockValues(year,
+            /// month,day, title).choiceDate);
+            // model.addAttribute("stockList", availableStock);
+            /// model.addAttribute("rentalManageDto", rentalManageDto);
+
         }
+
         return "rental/add";
     }
 

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -82,38 +82,25 @@ public class RentalManageController {
             @RequestParam(value = "year", required = false) Integer year,
             @RequestParam(value = "month", required = false) Integer month,
             @RequestParam(value = "day", required = false) Integer day,
-            @RequestParam(value = "title", required = false) Integer title) {
+            @RequestParam(value = "title", required = false) String title) {
         List<Account> accounts = this.accountService.findAll();
         List<Stock> stockList = this.stockService.findStockAvailableAll();
+        model.addAttribute("accounts", accounts);
+        model.addAttribute("rentalStatus", RentalStatus.values());
 
         if (year != null && month != null && day != null && title != null) {
             LocalDate localDate = LocalDate.of(year, month, day);
             java.sql.Date choiceDate = java.sql.Date.valueOf(localDate);
             List<Stock> availableStock = this.stockService.availableStockValues(choiceDate, title);
+            
             model.addAttribute("stockList", availableStock);
-
-            rentalManageDto.setId(null);
-            rentalManageDto.setEmployeeId(null);
-            rentalManageDto.setExpectedRentalOn(null);
-            rentalManageDto.setExpectedReturnOn(null);
-            rentalManageDto.setStockId(null);
-            rentalManageDto.setStatus(null);
-            rentalManageDto.setExpectedRentalOn(choiceDate);
-
             model.addAttribute("rentalManageDto", rentalManageDto);
+            rentalManageDto.setExpectedRentalOn(choiceDate);
 
         } else {
 
-            model.addAttribute("accounts", accounts);
             model.addAttribute("stockList", stockList);
-            model.addAttribute("rentalStatus", RentalStatus.values());
-
-        }
-
-        if (!model.containsAttribute("rentalManageDto")) {
-
             model.addAttribute("rentalManageDto", new RentalManageDto());
-
         }
 
         return "rental/add";

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -85,21 +85,12 @@ public class RentalManageController {
             @RequestParam(value = "title", required = false) Integer title) {
         List<Account> accounts = this.accountService.findAll();
         List<Stock> stockList = this.stockService.findStockAvailableAll();
-        /// Integer id = title + 1;
-        /// RentalManage rentalManage =
-        /// this.rentalManageService.findById(Long.valueOf(id));
-        // LocalDate localDate = LocalDate.of(year, month, day);
-        // java.sql.Date choiceDate = java.sql.Date.valueOf(localDate);
 
         if (year != null && month != null && day != null && title != null) {
             LocalDate localDate = LocalDate.of(year, month, day);
             java.sql.Date choiceDate = java.sql.Date.valueOf(localDate);
             List<Stock> availableStock = this.stockService.availableStockValues(choiceDate, title);
             model.addAttribute("stockList", availableStock);
-
-            // RentalManage rentalManage =
-            // this.rentalManageService.findById(Long.valueOf(id));
-            // RentalManageDto rentalManageDto = new RentalManageDto();
 
             rentalManageDto.setId(null);
             rentalManageDto.setEmployeeId(null);
@@ -122,12 +113,6 @@ public class RentalManageController {
         if (!model.containsAttribute("rentalManageDto")) {
 
             model.addAttribute("rentalManageDto", new RentalManageDto());
-
-            // RentalManageDto choicedDate = new RentalManageDto();
-            /// choicedDate.setExpectedRentalOn(this.stockService.availableStockValues(year,
-            /// month,day, title).choiceDate);
-            // model.addAttribute("stockList", availableStock);
-            /// model.addAttribute("rentalManageDto", rentalManageDto);
 
         }
 

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -93,9 +93,9 @@ public class RentalManageController {
             java.sql.Date choiceDate = java.sql.Date.valueOf(localDate);
             List<Stock> availableStock = this.stockService.availableStockValues(choiceDate, title);
             
+            rentalManageDto.setExpectedRentalOn(choiceDate);
             model.addAttribute("stockList", availableStock);
             model.addAttribute("rentalManageDto", rentalManageDto);
-            rentalManageDto.setExpectedRentalOn(choiceDate);
 
         } else {
 

--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -42,7 +42,7 @@ public class StockController {
 
     @GetMapping("/stock/index")
     public String index(Model model) {
-        List <Stock> stockList = this.stockService.findAll();
+        List<Stock> stockList = this.stockService.findAll();
 
         model.addAttribute("stockList", stockList);
 
@@ -114,7 +114,8 @@ public class StockController {
     }
 
     @PostMapping("/stock/{id}/edit")
-    public String update(@PathVariable("id") String id, @Valid @ModelAttribute StockDto stockDto, BindingResult result, RedirectAttributes ra) {
+    public String update(@PathVariable("id") String id, @Valid @ModelAttribute StockDto stockDto, BindingResult result,
+            RedirectAttributes ra) {
         try {
             if (result.hasErrors()) {
                 throw new Exception("Validation error.");
@@ -133,31 +134,28 @@ public class StockController {
         }
     }
 
-     @GetMapping("/stock/calendar") 
-    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month, Model model) { 
+    @GetMapping("/stock/calendar")
+    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month,
+            Model model) {
 
-        LocalDate today = year == null || month == null ? LocalDate.now() : LocalDate.of(year, month, 1); 
-        Integer targetYear = year == null ? today.getYear() : year; 
-        Integer targetMonth = today.getMonthValue(); 
-        LocalDate nowDate = LocalDate.now(ZoneId.of("Asia/Tokyo")); 
+        LocalDate today = year == null || month == null ? LocalDate.now() : LocalDate.of(year, month, 1);
+        Integer targetYear = year == null ? today.getYear() : year;
+        Integer targetMonth = today.getMonthValue();
+        LocalDate nowDate = LocalDate.now(ZoneId.of("Asia/Tokyo"));
 
-        LocalDate startDate = LocalDate.of(targetYear, targetMonth, 1); 
-        Integer daysInMonth = startDate.lengthOfMonth(); 
+        LocalDate startDate = LocalDate.of(targetYear, targetMonth, 1);
+        Integer daysInMonth = startDate.lengthOfMonth();
 
-        List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth); 
-        List<List<String>> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth); 
+        List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
+        List<List<String>> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
 
-        //List<String> availableStockId = this.stockService.availableStockValues(targetYear, targetMonth, daysInMonth, title, eachDay); 
+        model.addAttribute("targetYear", targetYear);
+        model.addAttribute("targetMonth", targetMonth);
+        model.addAttribute("daysOfWeek", daysOfWeek);
+        model.addAttribute("daysInMonth", daysInMonth);
+        model.addAttribute("nowDate", nowDate);
 
-        model.addAttribute("targetYear", targetYear); 
-        model.addAttribute("targetMonth", targetMonth); 
-        model.addAttribute("daysOfWeek", daysOfWeek); 
-        model.addAttribute("daysInMonth", daysInMonth); 
-        model.addAttribute("nowDate", nowDate); 
-
-        model.addAttribute("stocks", stocks); 
-
-        //model.addAttribute("stockList", availableStockId);
+        model.addAttribute("stocks", stocks);
 
         return "stock/calendar";
     }

--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -1,6 +1,7 @@
 package jp.co.metateam.library.controller;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -132,25 +133,31 @@ public class StockController {
         }
     }
 
-    @GetMapping("/stock/calendar")
-    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month, Model model) {
+     @GetMapping("/stock/calendar") 
+    public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month, Model model) { 
 
-        LocalDate today = year == null || month == null ? LocalDate.now() : LocalDate.of(year, month, 1);
-        Integer targetYear = year == null ? today.getYear() : year;
-        Integer targetMonth = today.getMonthValue();
+        LocalDate today = year == null || month == null ? LocalDate.now() : LocalDate.of(year, month, 1); 
+        Integer targetYear = year == null ? today.getYear() : year; 
+        Integer targetMonth = today.getMonthValue(); 
+        LocalDate nowDate = LocalDate.now(ZoneId.of("Asia/Tokyo")); 
 
-        LocalDate startDate = LocalDate.of(targetYear, targetMonth, 1);
-        Integer daysInMonth = startDate.lengthOfMonth();
+        LocalDate startDate = LocalDate.of(targetYear, targetMonth, 1); 
+        Integer daysInMonth = startDate.lengthOfMonth(); 
 
-        List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
-        List<String> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth); 
+        List<List<String>> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth); 
 
-        model.addAttribute("targetYear", targetYear);
-        model.addAttribute("targetMonth", targetMonth);
-        model.addAttribute("daysOfWeek", daysOfWeek);
-        model.addAttribute("daysInMonth", daysInMonth);
+        //List<String> availableStockId = this.stockService.availableStockValues(targetYear, targetMonth, daysInMonth, title, eachDay); 
 
-        model.addAttribute("stocks", stocks);
+        model.addAttribute("targetYear", targetYear); 
+        model.addAttribute("targetMonth", targetMonth); 
+        model.addAttribute("daysOfWeek", daysOfWeek); 
+        model.addAttribute("daysInMonth", daysInMonth); 
+        model.addAttribute("nowDate", nowDate); 
+
+        model.addAttribute("stocks", stocks); 
+
+        //model.addAttribute("stockList", availableStockId);
 
         return "stock/calendar";
     }

--- a/src/main/java/jp/co/metateam/library/repository/BookMstRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/BookMstRepository.java
@@ -1,4 +1,5 @@
 package jp.co.metateam.library.repository;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import jp.co.metateam.library.model.BookMst;
 
@@ -9,14 +10,13 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 
 public interface BookMstRepository extends JpaRepository<BookMst, Long> {
-	List<BookMst> findAll();
+  List<BookMst> findAll();
 
-	Optional<BookMst> findById(BigInteger id);
+  Optional<BookMst> findById(BigInteger id);
 
-//リスト 
-
-@Query("SELECT bm " + 
-        "FROM BookMst bm " + 
-        "WHERE deletedAt IS null") 
-  List<BookMst> bookTitle(); 
+  // リスト
+  @Query("SELECT bm " +
+      "FROM BookMst bm " +
+      "WHERE deletedAt IS null")
+  List<BookMst> bookTitle();
 }

--- a/src/main/java/jp/co/metateam/library/repository/BookMstRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/BookMstRepository.java
@@ -1,15 +1,22 @@
 package jp.co.metateam.library.repository;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import jp.co.metateam.library.model.BookMst;
 
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Query;
+
 public interface BookMstRepository extends JpaRepository<BookMst, Long> {
 	List<BookMst> findAll();
 
 	Optional<BookMst> findById(BigInteger id);
+
+//リスト 
+
+@Query("SELECT bm " + 
+        "FROM BookMst bm " + 
+        "WHERE deletedAt IS null") 
+  List<BookMst> bookTitle(); 
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.Stock;
 
-import java.sql.Date; 
+import java.sql.Date;
 
 @Repository
 public interface StockRepository extends JpaRepository<Stock, Long> {
@@ -25,7 +25,6 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
   List<Stock> findByBookMstIdAndStatus(Long book_id, Integer status);
 
   // 書籍ごとの総利用可能在庫取得→①ループの中でセットしていく②カウントして日付ごとの在庫数を表示させる際に使用
-
   // リスト
 
   @Query("SELECT s " +
@@ -62,7 +61,6 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
   int borrowingBook(Date day, Long id);
 
   // 日付ごとの貸出不可の在庫管理番号取得
-
   // リスト
 
   @Query("SELECT DISTINCT s " +

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -30,9 +30,9 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
   @Query("SELECT s " +
       "FROM Stock s " +
       "WHERE s.status = 0 " +
-      "AND s.bookMst.id = ?1 " +
+      "AND s.bookMst.title = ?1 " +
       "AND deletedAt IS null")
-  List<Stock> bookStockAvailable(Long id);
+  List<Stock> bookStockAvailable(String title);
 
   // 日付ごとの在庫数を表示させる際に使用（貸出待ち）
 
@@ -67,9 +67,9 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
       "FROM Stock s " +
       "LEFT OUTER JOIN RentalManage rm ON s.id = rm.stock.id " +
       "WHERE ?1 BETWEEN rm.expectedRentalOn AND rm.expectedReturnOn " +
-      "AND s.bookMst.id = ?2 " +
+      "AND s.bookMst.title = ?2 " +
       "AND s.status = 0 " +
       "AND deletedAt IS null")
-  List<Stock> lendableBook(Date choiceDate, Long id);
+  List<Stock> lendableBook(Date choiceDate, String title);
 
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -4,20 +4,74 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.Stock;
 
+import java.sql.Date; 
+
 @Repository
 public interface StockRepository extends JpaRepository<Stock, Long> {
-    
-    List<Stock> findAll();
 
-    List<Stock> findByDeletedAtIsNull();
+  List<Stock> findAll();
 
-    List<Stock> findByDeletedAtIsNullAndStatus(Integer status);
+  List<Stock> findByDeletedAtIsNull();
 
-	Optional<Stock> findById(String id);
-    
-    List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
+  List<Stock> findByDeletedAtIsNullAndStatus(Integer status);
+
+  Optional<Stock> findById(String id);
+
+  List<Stock> findByBookMstIdAndStatus(Long book_id, Integer status);
+
+  // 書籍ごとの総利用可能在庫取得→①ループの中でセットしていく②カウントして日付ごとの在庫数を表示させる際に使用
+
+  // リスト
+
+  @Query("SELECT s " +
+      "FROM Stock s " +
+      "WHERE s.status = 0 " +
+      "AND s.bookMst.id = ?1 " +
+      "AND deletedAt IS null")
+  List<Stock> bookStockAvailable(Long id);
+
+  // 日付ごとの在庫数を表示させる際に使用（貸出待ち）
+
+  @Query("SELECT COUNT (rm) " +
+      "FROM RentalManage rm " +
+      "LEFT OUTER JOIN Stock s ON rm.stock.id = s.id " +
+      "WHERE NOT(rm.expectedRentalOn > ?1 " +
+      "OR rm.expectedReturnOn < ?1) " +
+      "AND s.bookMst.id = ?2 " +
+      "AND s.status = 0 " +
+      "AND rm.status = 0 " +
+      "AND deletedAt IS null")
+  int borrowingWaitBook(Date day, Long id);
+
+  // 日付ごとの在庫数を表示させる際に使用（貸出中）
+
+  @Query("SELECT COUNT (rm) " +
+      "FROM RentalManage rm " +
+      "LEFT OUTER JOIN Stock s ON rm.stock.id = s.id " +
+      "WHERE NOT(rm.rentaledAt > ?1 " +
+      "OR rm.expectedReturnOn < ?1) " +
+      "AND s.bookMst.id = ?2 " +
+      "AND s.status = 0 " +
+      "AND rm.status = 1 " +
+      "AND deletedAt IS null")
+  int borrowingBook(Date day, Long id);
+
+  // 日付ごとの貸出不可の在庫管理番号取得
+
+  // リスト
+
+  @Query("SELECT DISTINCT s " +
+      "FROM Stock s " +
+      "LEFT OUTER JOIN RentalManage rm ON s.id = rm.stock.id " +
+      "WHERE ?1 BETWEEN rm.expectedRentalOn AND rm.expectedReturnOn " +
+      "AND s.bookMst.id = ?2 " +
+      "AND s.status = 0 " +
+      "AND deletedAt IS null")
+  List<Stock> lendableBook(Date choiceDate, Long id);
+
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -49,16 +49,16 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
 
   // 日付ごとの在庫数を表示させる際に使用（貸出中）
 
-  @Query("SELECT COUNT (rm) " +
-      "FROM RentalManage rm " +
-      "LEFT OUTER JOIN Stock s ON rm.stock.id = s.id " +
-      "WHERE NOT(rm.rentaledAt > ?1 " +
-      "OR rm.expectedReturnOn < ?1) " +
-      "AND s.bookMst.id = ?2 " +
+  @Query(value ="SELECT Count(*) " +
+      "FROM rental_manage rm " +
+      "LEFT OUTER JOIN stocks s ON rm.stock_id = s.id " +
+      "WHERE NOT(CAST(rm.rentaled_at as date) > :date " +
+      "OR rm.expected_return_on < :date) " +
+      "AND s.book_id = :book_id " +
       "AND s.status = 0 " +
       "AND rm.status = 1 " +
-      "AND deletedAt IS null")
-  int borrowingBook(Date day, Long id);
+      "AND deleted_at IS null",nativeQuery = true)
+   int borrowingBook(Date date, Long book_id);
 
   // 日付ごとの貸出不可の在庫管理番号取得
   // リスト

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -18,14 +18,15 @@ import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.repository.BookMstRepository;
 import jp.co.metateam.library.repository.StockRepository;
 
-import java.sql.Date; 
+import java.sql.Date;
+
 @Service
 public class StockService {
     private final BookMstRepository bookMstRepository;
     private final StockRepository stockRepository;
 
     @Autowired
-    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository){
+    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository) {
         this.bookMstRepository = bookMstRepository;
         this.stockRepository = stockRepository;
     }
@@ -36,10 +37,10 @@ public class StockService {
 
         return stocks;
     }
-    
+
     @Transactional
-    public List <Stock> findStockAvailableAll() {
-        List <Stock> stocks = this.stockRepository.findByDeletedAtIsNullAndStatus(Constants.STOCK_AVAILABLE);
+    public List<Stock> findStockAvailableAll() {
+        List<Stock> stocks = this.stockRepository.findByDeletedAtIsNullAndStatus(Constants.STOCK_AVAILABLE);
 
         return stocks;
     }
@@ -49,38 +50,38 @@ public class StockService {
         return this.stockRepository.findById(id).orElse(null);
     }
 
-    // 在庫カレンダーデータ取得 
-    // 書籍名取得 
-    @Transactional 
-    public List<BookMst> bookTitle() { 
-        return this.bookMstRepository.bookTitle(); 
-    } 
+    // 在庫カレンダーデータ取得
+    // 書籍名取得
+    @Transactional
+    public List<BookMst> bookTitle() {
+        return this.bookMstRepository.bookTitle();
+    }
 
-    // 書籍ごと総利用可能在庫取得 
-    @Transactional 
-    public List<Stock> bookStockAvailable(Long id) { 
-        return this.stockRepository.bookStockAvailable(id); 
-    } 
+    // 書籍ごと総利用可能在庫取得
+    @Transactional
+    public List<Stock> bookStockAvailable(Long id) {
+        return this.stockRepository.bookStockAvailable(id);
+    }
 
-    // 書籍ごと利用不可能在庫数取得（貸出待ち） 
-    @Transactional 
-    public int borrowingWaitBook(Date day, Long id) { 
-        return this.stockRepository.borrowingWaitBook(day, id); 
-    } 
+    // 書籍ごと利用不可能在庫数取得（貸出待ち）
+    @Transactional
+    public int borrowingWaitBook(Date day, Long id) {
+        return this.stockRepository.borrowingWaitBook(day, id);
+    }
 
-    // 書籍ごと利用不可能在庫数取得（貸出中） 
-    @Transactional 
-    public int borrowingBook(Date day, Long id) { 
-        return this.stockRepository.borrowingBook(day, id); 
-    } 
+    // 書籍ごと利用不可能在庫数取得（貸出中）
+    @Transactional
+    public int borrowingBook(Date day, Long id) {
+        return this.stockRepository.borrowingBook(day, id);
+    }
 
-    //書籍ごと利用可能在庫番号取得 
-    @Transactional 
-    public List<Stock> lendableBook(Date choiceDate, Long id) { 
-        return this.stockRepository.lendableBook(choiceDate, id); 
-    } 
+    // 書籍ごと利用可能在庫番号取得
+    @Transactional
+    public List<Stock> lendableBook(Date choiceDate, Long id) {
+        return this.stockRepository.lendableBook(choiceDate, id);
+    }
 
-    @Transactional 
+    @Transactional
     public void save(StockDto stockDto) throws Exception {
         try {
             Stock stock = new Stock();
@@ -101,7 +102,7 @@ public class StockService {
         }
     }
 
-    @Transactional 
+    @Transactional
     public void update(String id, StockDto stockDto) throws Exception {
         try {
             Stock stock = findById(id);
@@ -137,107 +138,78 @@ public class StockService {
         return daysOfWeek;
     }
 
-    public List<List<String>> generateValues(Integer year, Integer month, Integer daysInMonth) { 
-        // データの取得 
-        List<BookMst> bookTitleId = this.bookTitle(); 
+    public List<List<String>> generateValues(Integer year, Integer month, Integer daysInMonth) {
+        // データの取得
+        List<BookMst> bookTitleId = this.bookTitle();
+        int titleCount = bookTitleId.size();
+        List<String> titleArray = new ArrayList<>();
 
-        int titleCount = bookTitleId.size(); 
+        for (BookMst titleList : bookTitleId) {
+            titleArray.add(titleList.getTitle());
+        }
 
-        List<String> titleArray = new ArrayList<>(); 
+        List<Long> idArray = new ArrayList<>();
 
-        for (BookMst titleList : bookTitleId) { 
-            titleArray.add(titleList.getTitle()); 
-        } 
+        for (BookMst idList : bookTitleId) {
+            idArray.add(idList.getId());
+        }
 
-        List<Long> idArray = new ArrayList<>(); 
+        List<String> availableArray = new ArrayList<>();
+        List<String> dayStockArray = new ArrayList<>();
 
-        for (BookMst idList : bookTitleId) { 
-            idArray.add(idList.getId()); 
-        } 
+        for (Long id : idArray) {
+            List<Stock> StockAvailable = this.bookStockAvailable(id);
+            int stockCount = StockAvailable.size();
+            String stockCountString = String.valueOf(stockCount);
+            availableArray.add(stockCountString);
 
-        List<String> availableArray = new ArrayList<>(); 
-        List<String> dayStockArray = new ArrayList<>(); 
-        List<String> availableStockList = new ArrayList<>(); 
+            for (int dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) {
+                LocalDate localDate = LocalDate.of(year, month, dayOfMonth);
+                java.sql.Date day = java.sql.Date.valueOf(localDate);
 
-        for (Long id : idArray) { 
-            List<Stock> StockAvailable = this.bookStockAvailable(id); 
-            int stockCount = StockAvailable.size(); 
-            String stockCountString = String.valueOf(stockCount); 
-            availableArray.add(stockCountString); 
+                int borrowingWaitBook = this.borrowingWaitBook(day, id);
+                int borrowingBook = this.borrowingBook(day, id);
+                int dayStockCount = stockCount - (borrowingWaitBook + borrowingBook);
+                String dayStockCountString = String.valueOf(dayStockCount);
 
-            // List<String> dayStockInnerArray = new ArrayList<>(); 
-            for (int dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) { 
-                LocalDate localDate = LocalDate.of(year, month, dayOfMonth); 
-                java.sql.Date day = java.sql.Date.valueOf(localDate); 
+                if (dayStockCountString.equals("0")) {
+                    dayStockCountString = "×";
+                }
 
-                int borrowingWaitBook = this.borrowingWaitBook(day, id); 
-                int borrowingBook = this.borrowingBook(day, id); 
-                int dayStockCount = stockCount - (borrowingWaitBook + borrowingBook); 
-                String dayStockCountString = String.valueOf(dayStockCount); 
+                dayStockArray.add(dayStockCountString);
+            }
+        }
 
-                if (dayStockCountString.equals("0")) { 
-                    dayStockCountString = "×"; 
-                } 
+        List<List<String>> bigValues = new ArrayList<>();
 
-                /*List<Long> availableList = lendableBook(day, id); 
-                for (Long LongList : availableList) { 
-                    availableStockList.add(String.valueOf(LongList)); 
-                }*/ 
+        int roopCount = 0;
 
-                dayStockArray.add(dayStockCountString); 
-            } 
-            // dayStockArray.add(dayStockInnerArray.get()); 
-        } 
+        for (int i = 0; i < titleCount; i++) {
+            List<String> values = new ArrayList<>();
 
-        // List <Stock> lendableBook = this.lendableBook(choiceDate, choiceId); 
-        List<List<String>> bigValues = new ArrayList<>(); 
+            values.add(titleArray.get(i)); // 対象の書籍名
+            values.add(availableArray.get(i)); // 対象書籍の在庫総数
 
-        // FIXME ここで各書籍毎の日々の在庫を生成する処理を実装する 
-        // FIXME ランダムに値を返却するサンプルを実装している 
+            for (int j = 1; j <= daysInMonth; j++) {
+                values.add(dayStockArray.get(roopCount));
+                roopCount++;
+            }
+            bigValues.add(values);
+        }
+        return bigValues;
+    }
 
-        /* 
-         * String[] stockNum = {"1", "2", "3", "4", "×"}; 
-         * Random rnd = new Random(); 
-         */ 
+    // 貸出登録画面に遷移する際に在庫管理番号を渡すメソッド
+    public List<Stock> availableStockValues(java.sql.Date choiceDate, Integer title) {
 
-        int roopCount = 0; 
+        Long id = Long.valueOf(title + 1);
 
-        for (int i = 0; i < titleCount; i++) { 
-            List<String> values = new ArrayList<>(); 
+        List<Stock> availableList = lendableBook(choiceDate, id);
+        List<Stock> StockAvailable = this.bookStockAvailable(id);
 
-            values.add(titleArray.get(i)); // 対象の書籍名 
-            values.add(availableArray.get(i)); // 対象書籍の在庫総数 
+        StockAvailable.removeAll(availableList);
 
-            for (int j = 1; j <= daysInMonth; j++) { 
-                values.add(dayStockArray.get(roopCount)); 
-                roopCount++; 
-            } 
-            bigValues.add(values); 
-        } 
-        return bigValues; 
-    } 
+        return StockAvailable;
+    }
 
-
-    // 貸出登録画面に遷移する際に在庫管理番号を渡すメソッド 
-    public List<Stock> availableStockValues(java.sql.Date choiceDate, Integer title) { 
-
-        //LocalDate localDate = LocalDate.of(year, month, day); 
-        //java.sql.Date choiceDate = java.sql.Date.valueOf(localDate); 
-
-        Long id = Long.valueOf(title + 1); 
-
-        List<Stock> availableList = lendableBook(choiceDate, id); 
-        List<Stock> StockAvailable = this.bookStockAvailable(id); 
-
-        StockAvailable.removeAll(availableList);      
-
-        /*for (Long LongList : availableList) { 
-            availableStockList.add(String.valueOf(LongList)); 
-        }*/ 
-
-        return StockAvailable; 
-    } 
-
-} 
-
- 
+}

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -59,8 +59,8 @@ public class StockService {
 
     // 書籍ごと総利用可能在庫取得
     @Transactional
-    public List<Stock> bookStockAvailable(Long id) {
-        return this.stockRepository.bookStockAvailable(id);
+    public List<Stock> bookStockAvailable(String title) {
+        return this.stockRepository.bookStockAvailable(title);
     }
 
     // 書籍ごと利用不可能在庫数取得（貸出待ち）
@@ -77,8 +77,8 @@ public class StockService {
 
     // 書籍ごと利用可能在庫番号取得
     @Transactional
-    public List<Stock> lendableBook(Date choiceDate, Long id) {
-        return this.stockRepository.lendableBook(choiceDate, id);
+    public List<Stock> lendableBook(Date choiceDate, String title) {
+        return this.stockRepository.lendableBook(choiceDate, title);
     }
 
     @Transactional
@@ -140,25 +140,18 @@ public class StockService {
 
     public List<List<String>> generateValues(Integer year, Integer month, Integer daysInMonth) {
         // データの取得
-        List<BookMst> bookTitleId = this.bookTitle();
-        int titleCount = bookTitleId.size();
+        List<BookMst> bookTitleIds = this.bookTitle();
+        int titleCount = bookTitleIds.size();
         List<String> titleArray = new ArrayList<>();
-
-        for (BookMst titleList : bookTitleId) {
-            titleArray.add(titleList.getTitle());
-        }
-
         List<Long> idArray = new ArrayList<>();
-
-        for (BookMst idList : bookTitleId) {
-            idArray.add(idList.getId());
-        }
-
         List<String> availableArray = new ArrayList<>();
         List<String> dayStockArray = new ArrayList<>();
 
-        for (Long id : idArray) {
-            List<Stock> StockAvailable = this.bookStockAvailable(id);
+        for (BookMst bookList : bookTitleIds) {
+            titleArray.add(bookList.getTitle());
+            idArray.add(bookList.getId());
+ 
+            List<Stock> StockAvailable = this.bookStockAvailable(bookList.getTitle());
             int stockCount = StockAvailable.size();
             String stockCountString = String.valueOf(stockCount);
             availableArray.add(stockCountString);
@@ -167,8 +160,8 @@ public class StockService {
                 LocalDate localDate = LocalDate.of(year, month, dayOfMonth);
                 java.sql.Date day = java.sql.Date.valueOf(localDate);
 
-                int borrowingWaitBook = this.borrowingWaitBook(day, id);
-                int borrowingBook = this.borrowingBook(day, id);
+                int borrowingWaitBook = this.borrowingWaitBook(day, bookList.getId());
+                int borrowingBook = this.borrowingBook(day, bookList.getId());
                 int dayStockCount = stockCount - (borrowingWaitBook + borrowingBook);
                 String dayStockCountString = String.valueOf(dayStockCount);
 
@@ -200,12 +193,10 @@ public class StockService {
     }
 
     // 貸出登録画面に遷移する際に在庫管理番号を渡すメソッド
-    public List<Stock> availableStockValues(java.sql.Date choiceDate, Integer title) {
+    public List<Stock> availableStockValues(java.sql.Date choiceDate, String title) {
 
-        Long id = Long.valueOf(title + 1);
-
-        List<Stock> availableList = lendableBook(choiceDate, id);
-        List<Stock> StockAvailable = this.bookStockAvailable(id);
+        List<Stock> availableList = lendableBook(choiceDate, title);
+        List<Stock> StockAvailable = this.bookStockAvailable(title);
 
         StockAvailable.removeAll(availableList);
 

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -18,6 +18,7 @@ import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.repository.BookMstRepository;
 import jp.co.metateam.library.repository.StockRepository;
 
+import java.sql.Date; 
 @Service
 public class StockService {
     private final BookMstRepository bookMstRepository;
@@ -47,6 +48,37 @@ public class StockService {
     public Stock findById(String id) {
         return this.stockRepository.findById(id).orElse(null);
     }
+
+    // 在庫カレンダーデータ取得 
+    // 書籍名取得 
+    @Transactional 
+    public List<BookMst> bookTitle() { 
+        return this.bookMstRepository.bookTitle(); 
+    } 
+
+    // 書籍ごと総利用可能在庫取得 
+    @Transactional 
+    public List<Stock> bookStockAvailable(Long id) { 
+        return this.stockRepository.bookStockAvailable(id); 
+    } 
+
+    // 書籍ごと利用不可能在庫数取得（貸出待ち） 
+    @Transactional 
+    public int borrowingWaitBook(Date day, Long id) { 
+        return this.stockRepository.borrowingWaitBook(day, id); 
+    } 
+
+    // 書籍ごと利用不可能在庫数取得（貸出中） 
+    @Transactional 
+    public int borrowingBook(Date day, Long id) { 
+        return this.stockRepository.borrowingBook(day, id); 
+    } 
+
+    //書籍ごと利用可能在庫番号取得 
+    @Transactional 
+    public List<Stock> lendableBook(Date choiceDate, Long id) { 
+        return this.stockRepository.lendableBook(choiceDate, id); 
+    } 
 
     @Transactional 
     public void save(StockDto stockDto) throws Exception {
@@ -105,19 +137,107 @@ public class StockService {
         return daysOfWeek;
     }
 
-    public List<String> generateValues(Integer year, Integer month, Integer daysInMonth) {
-        // FIXME ここで各書籍毎の日々の在庫を生成する処理を実装する
-        // FIXME ランダムに値を返却するサンプルを実装している
-        String[] stockNum = {"1", "2", "3", "4", "×"};
-        Random rnd = new Random();
-        List<String> values = new ArrayList<>();
-        values.add("スッキリわかるJava入門 第4版"); // 対象の書籍名
-        values.add("10"); // 対象書籍の在庫総数
-        
-        for (int i = 1; i <= daysInMonth; i++) {
-            int index = rnd.nextInt(stockNum.length);
-            values.add(stockNum[index]);
-        }
-        return values;
-    }
-}
+    public List<List<String>> generateValues(Integer year, Integer month, Integer daysInMonth) { 
+        // データの取得 
+        List<BookMst> bookTitleId = this.bookTitle(); 
+
+        int titleCount = bookTitleId.size(); 
+
+        List<String> titleArray = new ArrayList<>(); 
+
+        for (BookMst titleList : bookTitleId) { 
+            titleArray.add(titleList.getTitle()); 
+        } 
+
+        List<Long> idArray = new ArrayList<>(); 
+
+        for (BookMst idList : bookTitleId) { 
+            idArray.add(idList.getId()); 
+        } 
+
+        List<String> availableArray = new ArrayList<>(); 
+        List<String> dayStockArray = new ArrayList<>(); 
+        List<String> availableStockList = new ArrayList<>(); 
+
+        for (Long id : idArray) { 
+            List<Stock> StockAvailable = this.bookStockAvailable(id); 
+            int stockCount = StockAvailable.size(); 
+            String stockCountString = String.valueOf(stockCount); 
+            availableArray.add(stockCountString); 
+
+            // List<String> dayStockInnerArray = new ArrayList<>(); 
+            for (int dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) { 
+                LocalDate localDate = LocalDate.of(year, month, dayOfMonth); 
+                java.sql.Date day = java.sql.Date.valueOf(localDate); 
+
+                int borrowingWaitBook = this.borrowingWaitBook(day, id); 
+                int borrowingBook = this.borrowingBook(day, id); 
+                int dayStockCount = stockCount - (borrowingWaitBook + borrowingBook); 
+                String dayStockCountString = String.valueOf(dayStockCount); 
+
+                if (dayStockCountString.equals("0")) { 
+                    dayStockCountString = "×"; 
+                } 
+
+                /*List<Long> availableList = lendableBook(day, id); 
+                for (Long LongList : availableList) { 
+                    availableStockList.add(String.valueOf(LongList)); 
+                }*/ 
+
+                dayStockArray.add(dayStockCountString); 
+            } 
+            // dayStockArray.add(dayStockInnerArray.get()); 
+        } 
+
+        // List <Stock> lendableBook = this.lendableBook(choiceDate, choiceId); 
+        List<List<String>> bigValues = new ArrayList<>(); 
+
+        // FIXME ここで各書籍毎の日々の在庫を生成する処理を実装する 
+        // FIXME ランダムに値を返却するサンプルを実装している 
+
+        /* 
+         * String[] stockNum = {"1", "2", "3", "4", "×"}; 
+         * Random rnd = new Random(); 
+         */ 
+
+        int roopCount = 0; 
+
+        for (int i = 0; i < titleCount; i++) { 
+            List<String> values = new ArrayList<>(); 
+
+            values.add(titleArray.get(i)); // 対象の書籍名 
+            values.add(availableArray.get(i)); // 対象書籍の在庫総数 
+
+            for (int j = 1; j <= daysInMonth; j++) { 
+                values.add(dayStockArray.get(roopCount)); 
+                roopCount++; 
+            } 
+            bigValues.add(values); 
+        } 
+        return bigValues; 
+    } 
+
+
+    // 貸出登録画面に遷移する際に在庫管理番号を渡すメソッド 
+    public List<Stock> availableStockValues(java.sql.Date choiceDate, Integer title) { 
+
+        //LocalDate localDate = LocalDate.of(year, month, day); 
+        //java.sql.Date choiceDate = java.sql.Date.valueOf(localDate); 
+
+        Long id = Long.valueOf(title + 1); 
+
+        List<Stock> availableList = lendableBook(choiceDate, id); 
+        List<Stock> StockAvailable = this.bookStockAvailable(id); 
+
+        StockAvailable.removeAll(availableList);      
+
+        /*for (Long LongList : availableList) { 
+            availableStockList.add(String.valueOf(LongList)); 
+        }*/ 
+
+        return StockAvailable; 
+    } 
+
+} 
+
+ 

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import jp.co.metateam.library.constants.Constants;
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.RentalManage;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.repository.BookMstRepository;
@@ -71,8 +72,8 @@ public class StockService {
 
     // 書籍ごと利用不可能在庫数取得（貸出中）
     @Transactional
-    public int borrowingBook(Date day, Long id) {
-        return this.stockRepository.borrowingBook(day, id);
+    public int borrowingBook(Date day, Long bookId) {
+        return this.stockRepository.borrowingBook(day, bookId); 
     }
 
     // 書籍ごと利用可能在庫番号取得
@@ -152,6 +153,7 @@ public class StockService {
             idArray.add(bookList.getId());
  
             List<Stock> StockAvailable = this.bookStockAvailable(bookList.getTitle());
+            //List<Stock> StockId = StockAvailable.getId();
             int stockCount = StockAvailable.size();
             String stockCountString = String.valueOf(stockCount);
             availableArray.add(stockCountString);

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -36,10 +36,19 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr>
-                                <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
-                                <td th:each="stock, stat : ${stocks}" th:text="${stock}"></td>
-                            </tr>
+                            <tr th:each="stock, stat : ${stocks}"> 
+                                <!-- FIXME ControllerやService側の処理とともに表示方法を考える --> 
+                                        <th:block th:each="bookData, iterStat : ${stock}"> 
+                                            <td th:if="${iterStat.index >= 2 and #dates.format(#dates.create(targetYear, targetMonth, iterStat.index -1), 'yyyy-MM-dd') >= #temporals.format(nowDate, 'yyyy-MM-dd') and bookData != '×'}"> 
+                                                <a th:href="@{/rental/add(year=${targetYear}, month=${targetMonth}, day=${iterStat.index-1}, title=${stat.index})}"> 
+                                                    <span th:text="${bookData}"></span> 
+                                                </a> 
+                                            </td> 
+                                            <td th:unless="${iterStat.index >= 2 and #dates.format(#dates.create(targetYear, targetMonth, iterStat.index-1), 'yyyy-MM-dd') >= #temporals.format(nowDate, 'yyyy-MM-dd') and bookData != '×'}"> 
+                                                <span th:text="${bookData}"></span> 
+                                            </td> 
+                                        </th:block> 
+                                    </tr> 
                         </tbody>
                     </table>
                 </div>

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -40,7 +40,7 @@
                                 <!-- FIXME ControllerやService側の処理とともに表示方法を考える --> 
                                         <th:block th:each="bookData, iterStat : ${stock}"> 
                                             <td th:if="${iterStat.index >= 2 and #dates.format(#dates.create(targetYear, targetMonth, iterStat.index -1), 'yyyy-MM-dd') >= #temporals.format(nowDate, 'yyyy-MM-dd') and bookData != '×'}"> 
-                                                <a th:href="@{/rental/add(year=${targetYear}, month=${targetMonth}, day=${iterStat.index-1}, title=${stocks.get(stat.index).get(0)})}"> 
+                                                <a th:href="@{/rental/add(year=${targetYear}, month=${targetMonth}, day=${iterStat.index-1}, title=${stock.get(0)})}"> 
                                                     <span th:text="${bookData}"></span> 
                                                 </a> 
                                             </td> 

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -40,7 +40,7 @@
                                 <!-- FIXME ControllerやService側の処理とともに表示方法を考える --> 
                                         <th:block th:each="bookData, iterStat : ${stock}"> 
                                             <td th:if="${iterStat.index >= 2 and #dates.format(#dates.create(targetYear, targetMonth, iterStat.index -1), 'yyyy-MM-dd') >= #temporals.format(nowDate, 'yyyy-MM-dd') and bookData != '×'}"> 
-                                                <a th:href="@{/rental/add(year=${targetYear}, month=${targetMonth}, day=${iterStat.index-1}, title=${stat.index})}"> 
+                                                <a th:href="@{/rental/add(year=${targetYear}, month=${targetMonth}, day=${iterStat.index-1}, title=${stocks.get(stat.index).get(0)})}"> 
                                                     <span th:text="${bookData}"></span> 
                                                 </a> 
                                             </td> 


### PR DESCRIPTION
・概要 

在庫カレンダー機能初期表示
日ごとのリンククリックで貸出登録画面へ遷移（貸出可能な在庫管理番号と日付をもって）

・テスト証跡 

在庫カレンダー画面の初期表示にタイトル、総利用可能在庫数、日ごとの利用可能在庫数が正しく表示されているか
現在日以降がリンクで表示されているか
リンクをクリックすると貸出登録画面に遷移し、貸出予定日にクリックした日付がセットされているか。在庫管理番号のプルダウンには貸出可能な在庫管理番号がセットされているか。

・備考 

特になし