### PR TITLE
土日色変更

### DIFF
--- a/src/main/resources/static/css/stock/calendar.css
+++ b/src/main/resources/static/css/stock/calendar.css
@@ -35,3 +35,11 @@
     padding: 5px;
     font-size: 14px;
 }
+
+.saturday {
+    color: blue;
+}
+
+.sunday {
+    color: red;
+}

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
 <head th:replace="~{common :: meta_header('在庫カレンダー',~{::link},~{::script})}">
     <title th:text="${title}+' | MTLibrary'"></title>
     <link rel="stylesheet" th:href="@{/css/stock/calendar.css}" />
     <script type="text/javascript" th:src="@{/js/stock/add.js}"></script>
 </head>
+
 <body>
     <div class="contents">
         <div th:replace="~{common :: main_sidebar}"></div>
@@ -13,9 +15,9 @@
             <div class="inner_contens">
                 <div class="page_title">在庫カレンダー</div>
                 <div class="month_change mb30">
-                    <div><a th:href="@{/stock/calendar(year=2024,month=*{targetMonth-1})}">前月</a></div>
+                    <div><a th:href="@{/stock/calendar(year=${targetMonth == 1} ? ${targetYear - 1} : ${targetYear}, month=${targetMonth == 1} ? 12 : ${targetMonth - 1})}">前月</a></div>
                     <div th:text="${targetYear + '年' + targetMonth + '月'}"></div>
-                    <div><a th:href="@{/stock/calendar(year=2024,month=*{targetMonth+1})}">翌月</a></div>
+                    <div><a th:href="@{/stock/calendar(year=${targetMonth == 12} ? ${targetYear + 1} : ${targetYear}, month=${targetMonth == 12} ? 1 : ${targetMonth + 1})}">翌月</a></div>
                 </div>
 
                 <div class="table_wrapper">
@@ -29,26 +31,33 @@
                             <tr>
                                 <th class="header_book" rowspan="2">書籍名</th>
                                 <th class="header_stock" rowspan="2">在庫数</th>
-                                <th class="header_days" th:colspan="${daysInMonth}" th:text="${targetYear + '年' + targetMonth + '月'}"></th>
+                                <th class="header_days" th:colspan="${daysInMonth}"
+                                    th:text="${targetYear + '年' + targetMonth + '月'}"></th>
                             </tr>
                             <tr class="days">
-                                <th th:each="day : ${daysOfWeek}" th:text="${day}"></th>
+                                <th th:each="day, dayStat : ${daysOfWeek}" 
+                                    th:class="${#strings.contains(day, '(土)')} ? 'saturday' : (${#strings.contains(day, '(日)')} ? 'sunday' : '')"
+                                    th:text="${day}" >
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
-                            <tr th:each="stock, stat : ${stocks}"> 
-                                <!-- FIXME ControllerやService側の処理とともに表示方法を考える --> 
-                                        <th:block th:each="bookData, iterStat : ${stock}"> 
-                                            <td th:if="${iterStat.index >= 2 and #dates.format(#dates.create(targetYear, targetMonth, iterStat.index -1), 'yyyy-MM-dd') >= #temporals.format(nowDate, 'yyyy-MM-dd') and bookData != '×'}"> 
-                                                <a th:href="@{/rental/add(year=${targetYear}, month=${targetMonth}, day=${iterStat.index-1}, title=${stock.get(0)})}"> 
-                                                    <span th:text="${bookData}"></span> 
-                                                </a> 
-                                            </td> 
-                                            <td th:unless="${iterStat.index >= 2 and #dates.format(#dates.create(targetYear, targetMonth, iterStat.index-1), 'yyyy-MM-dd') >= #temporals.format(nowDate, 'yyyy-MM-dd') and bookData != '×'}"> 
-                                                <span th:text="${bookData}"></span> 
-                                            </td> 
-                                        </th:block> 
-                                    </tr> 
+                            <tr th:each="stock, stat : ${stocks}">
+                                <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
+                                <th:block th:each="bookData, iterStat : ${stock}">
+                                    <td
+                                        th:if="${iterStat.index >= 2 and #dates.format(#dates.create(targetYear, targetMonth, iterStat.index -1), 'yyyy-MM-dd') >= #temporals.format(nowDate, 'yyyy-MM-dd') and bookData != '×'}">
+                                        <a
+                                            th:href="@{/rental/add(year=${targetYear}, month=${targetMonth}, day=${iterStat.index-1}, title=${stock.get(0)})}">
+                                            <span th:text="${bookData}"></span>
+                                        </a>
+                                    </td>
+                                    <td
+                                        th:unless="${iterStat.index >= 2 and #dates.format(#dates.create(targetYear, targetMonth, iterStat.index-1), 'yyyy-MM-dd') >= #temporals.format(nowDate, 'yyyy-MM-dd') and bookData != '×'}">
+                                        <span th:text="${bookData}"></span>
+                                    </td>
+                                </th:block>
+                            </tr>
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
・概要
土曜日の日付ラベルは青、日曜日の日付ラベルが赤で表示されるよう修正
「前月」、「翌月」へのリンククリックで年を跨げるよう修正

・テスト証跡
(土)を含んだ日付ラベルが青色で表示されているか
(日)を含んだ日付ラベルが青色で表示されているか
「前月」リンクをクリックし続けて年を跨げるか
「翌月」リンクをクリックし続けて年を跨げるか

・備考
特になし