### PR TITLE
在庫カレンダー年月検索機能追加

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -131,6 +131,14 @@ public class RentalManageController {
                     }
                 }
             }
+
+            // 貸出<返却チェック
+            String returnDateError = rentalManageDto.isReturnDateError(rentalManageDto);
+            if (returnDateError != null) {
+                result.addError(new FieldError("rentalManageDto", "expectedReturnOn", returnDateError));
+                throw new RuntimeException();
+            }
+
             if (result.hasErrors()) {
                 throw new Exception("Validation error.");
             }
@@ -227,6 +235,13 @@ public class RentalManageController {
             String DateError = rentalManageDto.isDateError(rentalManage, rentalManageDto);
             if (DateError != null) {
                 result.addError(new FieldError("rentalManageDto", "expectedRentalOn", DateError));
+                throw new RuntimeException();
+            }
+
+            // 貸出<返却チェック
+            String returnDateError = rentalManageDto.isReturnDateError(rentalManageDto);
+            if (returnDateError != null) {
+                result.addError(new FieldError("rentalManageDto", "expectedReturnOn", returnDateError));
                 throw new RuntimeException();
             }
 

--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -3,6 +3,7 @@ package jp.co.metateam.library.controller;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -17,12 +18,15 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jakarta.validation.Valid;
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.RentalManageDto;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.service.BookMstService;
 import jp.co.metateam.library.service.StockService;
 import jp.co.metateam.library.values.StockStatus;
 import lombok.extern.log4j.Log4j2;
+
+import java.util.stream.IntStream;
 
 /**
  * 在庫情報関連クラス
@@ -134,6 +138,14 @@ public class StockController {
         }
     }
 
+    /**
+     * 画面上に在庫カレンダーを表示させるためのプログラム
+     * 
+     * @param year  viewから受け取った表示させたい年の値
+     * @param month viewから受け取った表示させたい月の値
+     * @param model viewに値を渡すために利用
+     * @return 値を返すviewを指定
+     */
     @GetMapping("/stock/calendar")
     public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month,
             Model model) {
@@ -149,6 +161,15 @@ public class StockController {
         List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
         List<List<String>> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
 
+        // 年List作成(2006~2100)
+        List<Integer> yearList = IntStream.rangeClosed(2006, 2100).boxed().collect(Collectors.toList());
+        // 月リスト作成（1~12）]
+        List<Integer> monthList = IntStream.rangeClosed(1, 12).boxed().collect(Collectors.toList());
+        // 現在年格納
+        int nowYear = nowDate.getYear();
+        // 現在月格納
+        int nowMonth = nowDate.getMonthValue();
+
         model.addAttribute("targetYear", targetYear);
         model.addAttribute("targetMonth", targetMonth);
         model.addAttribute("daysOfWeek", daysOfWeek);
@@ -156,6 +177,18 @@ public class StockController {
         model.addAttribute("nowDate", nowDate);
 
         model.addAttribute("stocks", stocks);
+
+        // 年リストmodel.addAttribute
+        model.addAttribute("yearList", yearList);
+
+        // 月リストmodel.addAttribute
+        model.addAttribute("monthList", monthList);
+
+        // 現在年model.addAttribute
+        model.addAttribute("nowYear", nowYear);
+
+        // 現在月model.addAttribute
+        model.addAttribute("nowMonth", nowMonth);
 
         return "stock/calendar";
     }

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -87,4 +87,15 @@ public class RentalManageDto {
         }
         return null;
     }
+
+    // 貸出<返却チェック
+    public String isReturnDateError(RentalManageDto rentalManageDto) {
+        Date expectedRentalOn = rentalManageDto.getExpectedRentalOn();
+        Date expectedReturnOn = rentalManageDto.getExpectedReturnOn();
+
+        if(expectedRentalOn.after(expectedReturnOn)) {
+            return "返却予定日は貸出予定日より後の日付を選択してください";
+        }
+        return null;
+    }
 }

--- a/src/main/resources/static/css/stock/calendar.css
+++ b/src/main/resources/static/css/stock/calendar.css
@@ -43,3 +43,19 @@
 .sunday {
     color: red;
 }
+
+.search {
+    width: 300px;
+    display: flex;
+    justify-content: space-between;
+}
+
+#submit_btn {
+    width: 60px;
+    height: 25px;
+    font-size: 15px;
+    background-color: #9CF2D3;
+    color: #545454;
+    border-radius: 0.5rem;
+    border: none;
+}

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -14,10 +14,35 @@
             <div th:replace="~{common :: header}"></div>
             <div class="inner_contens">
                 <div class="page_title">在庫カレンダー</div>
+                <div class="search mb30">
+                    <form th:action="@{/stock/calendar}" method="get">
+                        <!--年プルダウン初期値現在年月設定、リストの中身をループで作成（selectタグ、optionタグ）-->
+                        <select id="years" name="year">
+                            <option th:each="choicedYear : ${yearList}" th:value="${choicedYear}"
+                                th:text="${choicedYear}" th:selected="${choicedYear == nowYear}"></option>
+                        </select>
+                        <!-- 年ラベル（labelタグ） -->
+                        <label>年</label>
+                        <!-- 月プルダウン初期値現在年月設定、リストの中身をループで作成（selectタグ、optionタグ） -->
+                        <select id="months" name="month">
+                            <option th:each="choicedMonth : ${monthList}" th:value="${choicedMonth}"
+                                th:text="${choicedMonth}" th:selected="${choicedMonth == nowMonth}"></option>
+                        </select>
+                        <!-- 月ラベル（labelタグ） -->
+                        <label>月&emsp;</label>
+                        <!-- 検索ボタン作成 リンク作成、上記プルダウンで選択された年月を渡す-->
+                        <button type="submit" id="submit_btn">検索</button>
+                        <!-- </div> -->
+                    </form>
+                </div>
                 <div class="month_change mb30">
-                    <div><a th:href="@{/stock/calendar(year=${targetMonth == 1} ? ${targetYear - 1} : ${targetYear}, month=${targetMonth == 1} ? 12 : ${targetMonth - 1})}">前月</a></div>
+                    <div>
+                        <a th:href="@{/stock/calendar(year=${targetMonth == 1} ? ${targetYear - 1} : ${targetYear}, month=${targetMonth == 1} ? 12 : ${targetMonth - 1})}">前月</a>
+                    </div>
                     <div th:text="${targetYear + '年' + targetMonth + '月'}"></div>
-                    <div><a th:href="@{/stock/calendar(year=${targetMonth == 12} ? ${targetYear + 1} : ${targetYear}, month=${targetMonth == 12} ? 1 : ${targetMonth + 1})}">翌月</a></div>
+                    <div>
+                        <a th:href="@{/stock/calendar(year=${targetMonth == 12} ? ${targetYear + 1} : ${targetYear}, month=${targetMonth == 12} ? 1 : ${targetMonth + 1})}">翌月</a>
+                    </div>
                 </div>
 
                 <div class="table_wrapper">
@@ -35,9 +60,9 @@
                                     th:text="${targetYear + '年' + targetMonth + '月'}"></th>
                             </tr>
                             <tr class="days">
-                                <th th:each="day, dayStat : ${daysOfWeek}" 
+                                <th th:each="day, dayStat : ${daysOfWeek}"
                                     th:class="${#strings.contains(day, '(土)')} ? 'saturday' : (${#strings.contains(day, '(日)')} ? 'sunday' : '')"
-                                    th:text="${day}" >
+                                    th:text="${day}">
                                 </th>
                             </tr>
                         </thead>


### PR DESCRIPTION
**概要**
・在庫カレンダー画面に年月検索機能追加
・貸出予定日＞返却予定日になっていても貸出登録、貸出編集できてしまう状態だったのを、エラーメッセージが出て、登録、編集できないよう修正

**テスト証跡**
・検索ボタン押下時、選択された年月の在庫カレンダーが正しく表示される
・プルダウンの初期表示が現在年月になっていること
・貸出予定日＞返却予定日で保存ボタン、変更ボタンを押下すると返却予定日選択欄の下にエラーメッセージが表示され、登録、編集ができないようになっていること

**備考**
・特になし
